### PR TITLE
update send dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,11 +63,12 @@ module.exports = function(root, options) {
 	function serve(req) {
 		var filePath = stripVersion(url.parse(req.url).pathname);
 
-		return send(req, filePath)
-			.maxage(filePath == req.url ? 0 : 1000 * 60 * 60 * 24 * 365)
-			.index(options.index || "index.html")
-			.hidden(options.hidden)
-			.root(root)
+		return send(req, filePath,{
+			maxage: filePath == req.url ? 0 : 1000 * 60 * 60 * 24 * 365,
+			index: options.index || "index.html",
+			ignore: options.hidden,
+			root: root
+		});
 	}
 
 	function middleware(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expressjs"
   ],
   "dependencies": {
-    "send": "~0.2.0"
+    "send": "~0.11.1"
   },
   "devDependencies": {
     "should": "~3.1.2",


### PR DESCRIPTION
this updates the send dependency due to the root path disclosure security advisory.
https://nodesecurity.io/advisories/56

using the node security command line tool, this is picked up as a vulnerability.
https://github.com/nodesecurity/nsp