### PR TITLE
Upgrade vulnerable dependency of send - ms 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expressjs"
   ],
   "dependencies": {
-    "send": "~0.11.1"
+    "send": "~0.12.3"
   },
   "devDependencies": {
     "should": "~3.1.2",


### PR DESCRIPTION
## What 
Send 0.11.1 uses 0.7.0 of ms so pulls in the vulnerable dependency. Send fixed this in version 0.12.3
https://github.com/pillarjs/send/blob/master/HISTORY.md#0123--2015-05-13

## Why
The Regular expression Denial of Service (ReDoS) vulnerability exists in the ms package, affecting ms version 0.7.0 and below. See:
* https://snyk.io/vuln/npm:ms:20151024
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8315