### PR TITLE
Updated dependency on "send" module to 0.15.3 (current latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expressjs"
   ],
   "dependencies": {
-    "send": "~0.12.3"
+    "send": "~0.15.3"
   },
   "devDependencies": {
     "should": "~3.1.2",


### PR DESCRIPTION
HOW
- Updated reference in package.json from "~0.12.3" to "~0.15.3"

WHY
- "send" 0.12.3 includes dependency on older version of the "ms" module which has a ReDOS vulnerability. See here for more information: https://snyk.io/vuln/npm:ms:20151024