### PR TITLE
A little change on Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Initialise the staticify helper with the path of your public directory:
 
 ```js
 var path = require('path');
-var statificy = require('staticify')(path.join(__dirname, 'public'));
+var staticify = require('staticify')(path.join(__dirname, 'public'));
 ```
 
 This returns an object with the following helpers:


### PR DESCRIPTION
A little ajust on Readme.md, section USAGE, where the name of package is write wrong: 'statificy' instead of 'staticify' , causing reference error when user copy/paste to their code"