### PR TITLE
Add support to specific route in express

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Generate a short (7-digit) md5 hash instead of the full (32-digit) one.
 * Type: Boolean
 * Default: `true`
 
+### mwRoute
+
+If you are using the staticify convenience middleware through a specific route, it is necessary to indicate the route in this option.
+
+* Type: String
+* Default: "/"
+
+```js
+// Example
+
+// ...
+var options = { mwRoute: '/assets' }
+var staticify = require('staticify')(path.join(__dirname, 'public'), options);
+
+// ...
+app.use('/assets', staticify.middleware);  // `app` is your express instance
+```
+
 ### sendOptions
 
 * Type: Object

--- a/README.md
+++ b/README.md
@@ -67,13 +67,10 @@ If you are using the staticify convenience middleware through a specific route, 
 * Default: "/"
 
 ```js
-// Example
-
-// ...
-var options = { mwRoute: '/assets' }
+var path = require('path');
+var options = { mwRoute: '/assets' };
 var staticify = require('staticify')(path.join(__dirname, 'public'), options);
 
-// ...
 app.use('/assets', staticify.middleware);  // `app` is your express instance
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Generate a short (7-digit) md5 hash instead of the full (32-digit) one.
 * Type: Boolean
 * Default: `true`
 
-### mwRoute
+### pathPrefix
 
 If you are using the staticify convenience middleware through a specific route, it is necessary to indicate the route in this option.
 
@@ -68,7 +68,7 @@ If you are using the staticify convenience middleware through a specific route, 
 
 ```js
 var path = require('path');
-var options = { mwRoute: '/assets' };
+var options = { pathPrefix: '/assets' };
 var staticify = require('staticify')(path.join(__dirname, 'public'), options);
 
 app.use('/assets', staticify.middleware);  // `app` is your express instance

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const staticify = (root, options) => {
         let defaultOptions = {
             includeAll: opts.includeAll || false,
             shortHash: opts.shortHash || true,
+            mwRoute: opts.mwRoute || '/',
             sendOptions: opts.sendOptions || {}
         };
 
@@ -74,7 +75,7 @@ const staticify = (root, options) => {
 
         fileNameParts.push(versions[p], fileNameParts.pop());
 
-        return path.posix.join(path.dirname(p), fileNameParts.join('.'));
+        return path.posix.join(opts.mwRoute, path.dirname(p), fileNameParts.join('.'));
     };
 
     // index.<hash>.js -> index.js

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const staticify = (root, options) => {
         let defaultOptions = {
             includeAll: opts.includeAll || false,
             shortHash: opts.shortHash || true,
-            mwRoute: opts.mwRoute || '/',
+            pathPrefix: opts.pathPrefix || '/',
             sendOptions: opts.sendOptions || {}
         };
 
@@ -75,7 +75,7 @@ const staticify = (root, options) => {
 
         fileNameParts.push(versions[p], fileNameParts.pop());
 
-        return path.posix.join(opts.mwRoute, path.dirname(p), fileNameParts.join('.'));
+        return path.posix.join(opts.pathPrefix, path.dirname(p), fileNameParts.join('.'));
     };
 
     // index.<hash>.js -> index.js

--- a/test/index.js
+++ b/test/index.js
@@ -61,7 +61,7 @@ describe('.getVersionedPath', () => {
     });
 
     it('should add a prefix route to the path', () => {
-        let versioned = staticify(ROOT, {mwRoute: '/prefix'}).getVersionedPath('/index.js');
+        let versioned = staticify(ROOT, {pathPrefix: '/prefix'}).getVersionedPath('/index.js');
 
         versioned = versioned.split('.');
         versioned.should.have.a.lengthOf(3);

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,17 @@ describe('.getVersionedPath', () => {
         /^[0-9a-f]{32}$/i.exec(versioned[1])[0].should.equal(versioned[1]);
     });
 
+    it('should add a prefix route to the path', () => {
+        let versioned = staticify(ROOT, {mwRoute: '/prefix'}).getVersionedPath('/index.js');
+
+        versioned = versioned.split('.');
+        versioned.should.have.a.lengthOf(3);
+        versioned[0].should.equal('/prefix/index');
+        versioned[2].should.equal('js');
+        versioned[1].should.have.a.lengthOf(7);
+        /^[0-9a-f]{7}$/i.exec(versioned[1])[0].should.equal(versioned[1]);
+    });
+
     it('shouldn\'t add a hash if the path isn\'t known', () => {
         staticify(ROOT).getVersionedPath('/unknown.js').should.equal('/unknown.js');
     });


### PR DESCRIPTION
Hi! 🙂

I added a new option that allows to use the integrated middleware through a specific route in express.

In the issue #15 had proposed a solution, but after reviewing the code calmly, I realized that the problem was only in the method that returns the versioned path: `getVersionedPath`.

It happens because when adding a route for the middleware, the method `getVersionedPath` has no knowledge of it, and continues to return the direct path.

With the new option it is possible to specify that the middleware will pass through a route.

The new option is used in the `getVersionedPath` method. In this way, it returns the path correctly even when there is a specific route for the middleware.

Example of use:

```js
var path = require('path');
var options = { mwRoute: '/assets' }
var staticify = require('staticify')(path.join(__dirname, '/public'), options);

app.use('/assets', staticify.middleware);
app.locals.assets = staticify.getVersionedPath;
```

I await your comments. 👍

Fixes #15