### PR TITLE
Fix issue with sendOptions.maxAge being overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The version hashes are the md5 of the contents of the static asset. Thus, every 
 var path = require('path');
 var staticify = require('staticify')(path.join(__dirname, 'public'));
 
-...
+// ...
 app.use(staticify.middleware);
 
 app.helpers({getVersionedPath: staticify.getVersionedPath});
@@ -45,6 +45,12 @@ And in your template:
 ```
 
 ## Options
+
+Options are specified as the second parameter to `staticify`:
+
+```js
+var staticify = require('staticify')(path.join(__dirname, 'public'), options);
+```
 
 ### includeAll
 
@@ -75,6 +81,15 @@ var staticify = require('staticify')(path.join(__dirname, 'public'), options);
 app.use('/assets', staticify.middleware);  // `app` is your express instance
 ```
 
+### maxAgeNonHashed
+
+* Type: String | Number
+* Default: `0`
+
+`maxAge` for assets without a hash such as `/image.png` passed to [send](https://github.com/pillarjs/send).
+
+Can be defined as a number of milliseconds or string accepted by [ms](https://www.npmjs.org/package/ms#readme) module (eg. `'5d'`, `'1y'`, etc.)
+
 ### sendOptions
 
 * Type: Object
@@ -86,11 +101,11 @@ You can pass any [send](https://github.com/pillarjs/send) options; used in `midd
 
 Install from npm:
 
-```
+```sh
 npm install staticify
 ```
 
-Initialise the staticify helper with the path of your public directory:
+Initialize the staticify helper with the path of your public directory:
 
 ```js
 var path = require('path');

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const send = require('send');
 
 const staticify = (root, options) => {
     const MAX_AGE = 1000 * 60 * 60 * 24 * 365; // 1 year in milliseconds
+    let sendOptsNonVersioned;
 
     const setOptions = opts => {
         opts = opts || {};
@@ -28,12 +29,13 @@ const staticify = (root, options) => {
         defaultOptions.sendOptions.root = root;
         defaultOptions.sendOptions.maxAge = defaultOptions.sendOptions.maxAge || MAX_AGE;
 
+        sendOptsNonVersioned = Object.assign({}, defaultOptions.sendOptions);
+        sendOptsNonVersioned.maxAge = defaultOptions.maxAgeNonHashed;
+
         return defaultOptions;
     };
 
     const opts = setOptions(options);
-    const sendOptsNonVersioned = Object.assign({}, opts.sendOptions);
-    sendOptsNonVersioned.maxAge = opts.maxAgeNonHashed;
 
     const cachedMakeHash = memoizee(filePath => {
         const fileStr = fs.readFileSync(filePath, 'utf8');

--- a/test/index.js
+++ b/test/index.js
@@ -81,8 +81,9 @@ describe('.serve', () => {
         let server;
 
         before(done => {
+            const staticifyObj = staticify(ROOT);
             server = http.createServer((req, res) => {
-                staticify(ROOT).serve(req).pipe(res);
+                staticifyObj.serve(req).pipe(res);
             });
             server.listen(12321, done);
         });
@@ -119,8 +120,9 @@ describe('.serve', () => {
         let server;
 
         before(done => {
+            const staticifyObj = staticify(ROOT, {shortHash: false});
             server = http.createServer((req, res) => {
-                staticify(ROOT, {shortHash: false}).serve(req).pipe(res);
+                staticifyObj.serve(req).pipe(res);
             });
             server.listen(12321, done);
         });
@@ -157,12 +159,14 @@ describe('.serve', () => {
         let server;
 
         before(done => {
+            const staticifyObj = staticify(ROOT, {
+                maxAgeNonHashed: 7200 * 1000,
+                sendOptions: {
+                    maxAge: 3600 * 1000 // milliseconds
+                }
+            });
             server = http.createServer((req, res) => {
-                staticify(ROOT, {
-                    sendOptions: {
-                        maxAge: 3600 * 1000 // milliseconds
-                    }
-                }).serve(req).pipe(res);
+                staticifyObj.serve(req).pipe(res);
             });
             server.listen(12321, done);
         });
@@ -173,7 +177,7 @@ describe('.serve', () => {
 
         it('should serve files without a hash tag', done => {
             http.get('http://localhost:12321/index.js', res => {
-                res.headers['cache-control'].includes('max-age=0').should.be.true();
+                res.headers['cache-control'].includes('max-age=7200').should.be.true();
                 res.statusCode.should.equal(200);
                 done();
             });


### PR DESCRIPTION
This fix resolves issue with `sendOptions.maxAge` being overwritten when 404 is returned.
The following scenario resets the maxAge property:

1. Load static file which exists (maxAge respects configured `sendOptions`)
2. Load static file which does not exist (maxAge is set to `0`)
3. Load static file which exists (maxAge is set still to `0` and `MAX_AGE` is used instead)