### PR TITLE
Refresh should refresh file hashes by clearing the memoized hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.nyc_output/
 /coverage/
 /node_modules/
+/test/variable_file.txt

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ const staticify = (root, options) => {
     };
 
     const refresh = () => {
+        cachedMakeHash.clear();
         versions = buildVersionHash(root);
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -279,10 +279,9 @@ describe('.refresh', () => {
         fs.writeFileSync(path.join(__dirname, 'variable_file.txt'), 'File Content 1');
 
         const staticifyObj = staticify(ROOT);
-
         const versionedPath = staticifyObj.getVersionedPath('/test/variable_file.txt');
-
         const versioned = versionedPath.split('.');
+
         versioned.should.have.a.lengthOf(3);
         versioned[0].should.equal('/test/variable_file');
         versioned[2].should.equal('txt');

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const should = require('should');
@@ -270,5 +271,29 @@ describe('.replacePaths', () => {
         lines[1].should.match(/test\/font\.[0-9a-f]{32}\.woff2/i);
         results.includes('test/font.woff').should.be.false();
         results.includes('test/font.woff2').should.be.false();
+    });
+});
+
+describe('.refresh', () => {
+    it('should empty the cache of file hashes after a refresh()', () => {
+        fs.writeFileSync(path.join(__dirname, 'variable_file.txt'), 'File Content 1');
+
+        const staticifyObj = staticify(ROOT);
+
+        const versionedPath = staticifyObj.getVersionedPath('/test/variable_file.txt');
+
+        const versioned = versionedPath.split('.');
+        versioned.should.have.a.lengthOf(3);
+        versioned[0].should.equal('/test/variable_file');
+        versioned[2].should.equal('txt');
+
+        staticifyObj.refresh();
+
+        fs.writeFileSync(path.join(__dirname, 'variable_file.txt'), 'File Content 2');
+
+        const versionedPath2 = staticifyObj.getVersionedPath('/test/variable_file.txt');
+
+        versionedPath2.should.have.a.lengthOf(31);
+        versionedPath2.should.not.equal(versionedPath);
     });
 });


### PR DESCRIPTION
I've hit an issue where I wanted my express server to return the new paths of javascript/css assets on livereload (for example, first load `/main.df75ab9.js`, after livereload `/main.db7a554.js`).

However for now staticify will keep the original hashes in its cache for a filename, even after the file changes and the use of `staticify.refresh()`, thus preventing `getVersionedPath` from returning the new `shortHash` for a filename.

This PR makes sure that we clear the memoized cache of filename-to-hashes in `refresh()`, so that files that have changed and have new hashes can have their new shortHash-paths returned by `getVersionedPath`.