### PR TITLE
Travis: switch to `cache: npm` and remove `npm i`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ os:
   - linux
   - windows
 
-install:
-  - npm install
-
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run test:cov; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then npm run test; fi
@@ -22,9 +19,7 @@ script:
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_NODE_VERSION" = "10" ]]; then npm run coveralls; fi
 
-cache:
-  directories:
-    - node_modules
+cache: npm
 
 notifications:
   email: false


### PR DESCRIPTION
This way Travis caches the proper dirs itself and also uses `npm ci` when possible.