### PR TITLE
Fix handling of a URL which has a non-hash componenet in the place of a hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,11 +92,13 @@ const staticify = (root, options) => {
 
         const fileName = path.basename(p);
         const fileNameParts = fileName.split('.');
+        const fileNameHash = fileNameParts[fileNameParts.length - 2];
         const re = new RegExp(`^[0-9a-f]{${HASH_LEN}}$`, 'i');
+        const reResult = re.exec(fileNameHash);
 
         if (fileNameParts.length >= 3 &&
-            fileNameParts[fileNameParts.length - 2].length === HASH_LEN &&
-            re.exec(fileNameParts[fileNameParts.length - 2])[0] === fileNameParts[fileNameParts.length - 2]
+            fileNameHash.length === HASH_LEN &&
+            (reResult && reResult[0] === fileNameHash)
         ) {
             const stripped = fileNameParts.slice(0, fileNameParts.length - 2);
 

--- a/index.js
+++ b/index.js
@@ -92,14 +92,15 @@ const staticify = (root, options) => {
 
         const fileName = path.basename(p);
         const fileNameParts = fileName.split('.');
-        const fileNameHash = fileNameParts[fileNameParts.length - 2];
+        const fileNameHashPosition = fileNameParts.length - 2;
+        const fileNameHash = fileNameParts[fileNameHashPosition];
         const re = new RegExp(`^[0-9a-f]{${HASH_LEN}}$`, 'i');
         const reResult = re.exec(fileNameHash);
 
         if (fileNameParts.length >= 3 && fileNameHash.length === HASH_LEN &&
             (reResult && reResult[0] === fileNameHash)
         ) {
-            const stripped = fileNameParts.slice(0, fileNameParts.length - 2);
+            const stripped = fileNameParts.slice(0, fileNameHashPosition);
 
             stripped.push(fileNameParts[fileNameParts.length - 1]);
 

--- a/index.js
+++ b/index.js
@@ -96,8 +96,7 @@ const staticify = (root, options) => {
         const re = new RegExp(`^[0-9a-f]{${HASH_LEN}}$`, 'i');
         const reResult = re.exec(fileNameHash);
 
-        if (fileNameParts.length >= 3 &&
-            fileNameHash.length === HASH_LEN &&
+        if (fileNameParts.length >= 3 && fileNameHash.length === HASH_LEN &&
             (reResult && reResult[0] === fileNameHash)
         ) {
             const stripped = fileNameParts.slice(0, fileNameParts.length - 2);

--- a/test/index.js
+++ b/test/index.js
@@ -32,9 +32,17 @@ describe('.stripVersion', () => {
         staticify(ROOT).stripVersion(path.normalize('/script.js')).should.equal(path.normalize('/script.js'));
     });
 
+    it('should not fail when the path contains a 7 character string that is not a hash', () => {
+        staticify(ROOT).stripVersion(path.normalize('/script.abcdefg.html')).should.equal(path.normalize('/script.abcdefg.html'));
+    });
+
     it('should strip the (long) hash from a path when necessary', () => {
         staticify(ROOT, {shortHash: false}).stripVersion(path.normalize('/script.4e2502b01a4c92b0a51b1a5a3271eab6.js')).should.equal(path.normalize('/script.js'));
         staticify(ROOT, {shortHash: false}).stripVersion(path.normalize('/script.js')).should.equal(path.normalize('/script.js'));
+    });
+
+    it('should not fail when the path contains a 32 character string that is not a hash', () => {
+        staticify(ROOT).stripVersion(path.normalize('/script.abcdefgabcdefgabcdefgabcdefgabcd.html')).should.equal(path.normalize('/script.abcdefgabcdefgabcdefgabcdefgabcd.html'));
     });
 });
 


### PR DESCRIPTION
In the event a URL contains a 7 or 32-character segment where there would normally be a hash and exception would be raised:

`TypeError: Cannot read property '0' of null
    at Object.stripVersion (<omitted>/frontend/node_modules/staticify/index.js:90:61)`

This PR fixes this by handling the possibility that the RegEx check would fail by completing a null check. 